### PR TITLE
fix: undoStack.length === 1일 때 에러 처리

### DIFF
--- a/src/components/canvas/index.tsx
+++ b/src/components/canvas/index.tsx
@@ -74,7 +74,8 @@ function Canvas({ img, saveImage }: CanvasProps) {
     if (undoStack.length === 0) return
     if (undoStack.length === 1) {
       setRedoStack((prevState) => [...prevState, undoStack[0]])
-      ctx.clearRect(0, 0, canvas.width, canvas.height)
+      ctx.fillStyle = '#FFFFFF'
+      ctx.fillRect(0, 0, canvas.width, canvas.height)
       setUndoStack([])
       return
     }


### PR DESCRIPTION
캔버스를 아예 초기화하는 것이 아니라 하얀색 배경으로 채우도록